### PR TITLE
feat: Cloudflare Workersへのデプロイ設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-デジクリのプロモーションサイト [digicre.net](https://digicre.net/) の リポジトリです。
+# digicre.net
+
+デジクリの公式ウェブサイト [digicre.net](https://digicre.net/) の リポジトリです。
 
 ## 開発方法
 
 パッケージマネージャーにpnpmを使用しています。
+
+```bash
+pnpm install
+```
 
 ```bash
 pnpm dev

--- a/public/.assetsignore
+++ b/public/.assetsignore
@@ -1,0 +1,1 @@
+_redirects

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+/digicre-fes/ https://digicre-fes.archives.digicre.net/ 301
+/digigame-expo-2017/ https://digigame-expo-2017.digicre.net/ 301
+/digigame-expo-2019/ https://digigame-expo-2019.digicre.net/ 301

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "digicre",
+  "compatibility_date": "2025-11-07",
+  "assets": {
+    "directory": "./out/"
+  }
+}


### PR DESCRIPTION
## 概要

現在GitHub Pagesにデプロイされているデジクリの公式ウェブサイトを、Cloudflare Workersへ移行する。

Next.jsではSSGとしてすべてのページを静的にエクスポートしているので、生成されたディレクトリをStatic Assetsに指定すれば完全無料で運用できる。

> Requests to static assets are free and unlimited.
>
> [Pricing · Cloudflare Workers docs](https://developers.cloudflare.com/workers/platform/pricing/#workers)

移行にあたり、以下のリポジトリからデプロイされているページにアクセスができなくなるので、リダイレクトを設定した。

- https://github.com/SIT-DigiCre/digicre-fes
- https://github.com/SIT-DigiCre/digigame-expo-2017
- https://github.com/SIT-DigiCre/digigame-expo-2019

## 参考

- [Cloudflare Workersでリダイレクトを設定する | ほみろに](https://homironi.com/articles/1rzo1xgl9sna9y2apleb8of4/)
- [Redirects · Cloudflare Workers docs](https://developers.cloudflare.com/workers/static-assets/redirects/)

## マージ後の移行手順

1. Cloudflare Workersでこのリポジトリからの継続的なデプロイを設定する。
1. `workers.dev`ドメインのデプロイURLにアクセスし、正しく表示できることを確認。
1. Cloudflare RegistrarのDNS設定からGitHub Pagesに関連するAレコード4つを削除する。
1. このリポジトリの設定からGitHub Pagesのドメイン連携を解除する。
1. Cloudflare Workersの設定で`digicre.net`をこのリポジトリのプロジェクトに紐づける。
1. `digicre.net`でアクセスできることを確認。
1. 上記3つのリポジトリでGitHub Pagesとの連携を解除。
1. このリポジトリの名前を`SIT-Digicre.github.io`から`digicre.net`に変更する。